### PR TITLE
test other cas versions

### DIFF
--- a/.github/workflows/initializr-build.yml
+++ b/.github/workflows/initializr-build.yml
@@ -13,7 +13,9 @@ env:
 
 on:
   push:
-    branches: [ verstiontest ]
+    branches: [ master  ]
+  pull_request:
+    branches: [ master  ]
 
 ##########################################################################
 

--- a/.github/workflows/initializr-build.yml
+++ b/.github/workflows/initializr-build.yml
@@ -46,7 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cas-version: [6.3.3, 6.4.0-RC2, 6.4.0-SNAPSHOT]
+        cfg:
+          - { casVersion: 6.3.3, bootVersion: 2.3.7.RELEASE }
+          - { casVersion: 6.4.0-RC2, bootVersion: 2.4.2 }
+          - { casVersion: 6.4.0-SNAPSHOT, bootVersion: 2.4.2 }
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -59,7 +62,7 @@ jobs:
         with:
           name: binary-artifacts
       - name: Validate Overlay
-        run: ./ci/validate-cas-overlay.sh ${{ matrix.cas-version }}
+        run: ./ci/validate-cas-overlay.sh ${{ matrix.cfg.casVersion }} ${{ matrix.cfg.bootVersion }}
   validate-cas-mgmt-overlay:
     needs: [build]
     runs-on: ubuntu-latest

--- a/.github/workflows/initializr-build.yml
+++ b/.github/workflows/initializr-build.yml
@@ -13,9 +13,7 @@ env:
 
 on:
   push:
-    branches: [ master  ]
-  pull_request:
-    branches: [ master  ]
+    branches: [ verstiontest ]
 
 ##########################################################################
 
@@ -41,15 +39,45 @@ jobs:
         with:
           name: binary-artifacts
           path: ./**/build/libs/*.*
-  validate-cas-overlay:
+  ##########################################################################
+  supported-versions:
     needs: [build]
+    runs-on: ubuntu-latest
+    outputs:
+      supported-versions: ${{ steps.get-supported-versions.outputs.supported-versions }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ env.JDK_CURRENT }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: binary-artifacts
+      - id: run-initializr
+        name: Run Initializer to get supported versions
+        run: |
+          . ./ci/functions.sh
+          java -jar app/build/libs/app.jar &
+          waitForInitializr
+      - id: print-supported-versions
+        name: Print supported versions
+        run: curl -q http://localhost:8081/actuator/supportedVersions | jq .
+      - id: get-supported-versions
+        name: Get supported versions for matrix
+        run: echo "::set-output name=supported-versions::$(curl -q http://localhost:8081/actuator/supportedVersions)]}"
+      - id: stop-initializr
+        name: Stop Initializr
+        run: |
+          . ./ci/functions.sh
+          stopInitializr
+  ##########################################################################
+  validate-cas-overlay:
+    needs: [supported-versions]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cfg:
-          - { casVersion: 6.3.3, bootVersion: 2.3.7.RELEASE }
-          - { casVersion: 6.4.0-RC2, bootVersion: 2.4.3 }
-          - { casVersion: 6.4.0-SNAPSHOT, bootVersion: 2.4.4 }
+        versions: ${{fromJSON(needs.supported-versions.outputs.supported-versions)}}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -62,7 +90,7 @@ jobs:
         with:
           name: binary-artifacts
       - name: Validate Overlay
-        run: ./ci/validate-cas-overlay.sh ${{ matrix.cfg.casVersion }} ${{ matrix.cfg.bootVersion }}
+        run: ./ci/validate-cas-overlay.sh ${{ matrix.versions.casVersion }} ${{ matrix.versions.bootVersion }}
   validate-cas-mgmt-overlay:
     needs: [build]
     runs-on: ubuntu-latest

--- a/.github/workflows/initializr-build.yml
+++ b/.github/workflows/initializr-build.yml
@@ -44,6 +44,9 @@ jobs:
   validate-cas-overlay:
     needs: [build]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cas-version: [6.3.3, 6.4.0-RC2, 6.4.0-SNAPSHOT]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
@@ -56,7 +59,7 @@ jobs:
         with:
           name: binary-artifacts
       - name: Validate Overlay
-        run: ./ci/validate-cas-overlay.sh
+        run: ./ci/validate-cas-overlay.sh ${{ matrix.cas-version }}
   validate-cas-mgmt-overlay:
     needs: [build]
     runs-on: ubuntu-latest

--- a/.github/workflows/initializr-build.yml
+++ b/.github/workflows/initializr-build.yml
@@ -48,8 +48,8 @@ jobs:
       matrix:
         cfg:
           - { casVersion: 6.3.3, bootVersion: 2.3.7.RELEASE }
-          - { casVersion: 6.4.0-RC2, bootVersion: 2.4.2 }
-          - { casVersion: 6.4.0-SNAPSHOT, bootVersion: 2.4.2 }
+          - { casVersion: 6.4.0-RC2, bootVersion: 2.4.3 }
+          - { casVersion: 6.4.0-SNAPSHOT, bootVersion: 2.4.4 }
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ CAS Initializr is a Spring Boot application and can be run using the following c
 Or run the Docker image:
 
 ```bash  
-imageTag=(`./gradlew casVersion --q`) && docker run --rm -p 8080:8080 -t apereo/cas-initializr:$imageTag 
+imageTag=(`./gradlew casersion --q`) && docker run --rm -p 8080:8080 -t apereo/cas-initializr:$imageTag 
 ```
 
 The service will be available on `http://localhost:8080`.
@@ -49,8 +49,10 @@ curl http://localhost:8080/starter.tgz -d dependencies=core | tar -xzvf -
 
 #### Generate a CAS overlay for a specific version:
 
+Must specify the appropriate spring boot version for the specified casVersion.
+
 ```bash
-curl http://localhost:8080/starter.tgz -d "dependencies=core,oidc&casVersion=6.3.3" | tar  -xzvf -
+curl http://localhost:8080/starter.tgz -d "dependencies=core,oidc&casVersion=6.3.3&bootVersion=2.3.7.RELEASE" | tar  -xzvf -
 ```
 
 #### Generate overlay projects for other CAS related applications:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ CAS Initializr is a Spring Boot application and can be run using the following c
 Or run the Docker image:
 
 ```bash  
-imageTag=(`./gradlew casersion --q`) && docker run --rm -p 8080:8080 -t apereo/cas-initializr:$imageTag 
+imageTag=(`./gradlew casVersion --q`) && docker run --rm -p 8080:8080 -t apereo/cas-initializr:$imageTag 
 ```
 
 The service will be available on `http://localhost:8080`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation "org.apereo.cas:cas-server-core-api-configuration-model:${casVersion}"
 
     runtimeOnly "org.springframework.boot:spring-boot-starter-tomcat"
+
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 bootBuildImage {
@@ -63,7 +65,6 @@ bootRun {
     def appArgList = []
     args = appArgList
 }
-
 
 processResources {
     filesMatching(['**/*.yml', '**/*.properties', '**/*.md', '**/*.mustache']) {

--- a/app/src/main/java/org/apereo/cas/initializr/config/CasCustomInitializrConfiguration.java
+++ b/app/src/main/java/org/apereo/cas/initializr/config/CasCustomInitializrConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Bean;
 
 /**
  * Custom configuration that might be used by CI or UI, but not for initializr arguments.
+ * @author Hal Deadman
  */
 @EnableConfigurationProperties(CasCustomInitializrConfiguration.class)
 @ConfigurationProperties(value = "cas-initializr")

--- a/app/src/main/java/org/apereo/cas/initializr/config/CasCustomInitializrConfiguration.java
+++ b/app/src/main/java/org/apereo/cas/initializr/config/CasCustomInitializrConfiguration.java
@@ -1,0 +1,32 @@
+package org.apereo.cas.initializr.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.apereo.cas.initializr.web.SupportedVersionsEndpoint;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Custom configuration that might be used by CI or UI, but not for initializr arguments.
+ */
+@EnableConfigurationProperties(CasCustomInitializrConfiguration.class)
+@ConfigurationProperties(value = "cas-initializr")
+@Getter
+@Setter
+public class CasCustomInitializrConfiguration {
+
+    private List<SupportedVersion> supportedVersions = new ArrayList<>();
+
+    /**
+     * Controller used by CI to get supported version information for overlay matrix.
+     * @return SupportedVersionsEndpoint
+     */
+    @Bean
+    public SupportedVersionsEndpoint supportedVersionsEndpoint() {
+        return new SupportedVersionsEndpoint(supportedVersions);
+    }
+
+}

--- a/app/src/main/java/org/apereo/cas/initializr/config/SupportedVersion.java
+++ b/app/src/main/java/org/apereo/cas/initializr/config/SupportedVersion.java
@@ -4,7 +4,8 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Information about versions of CAS supported by the cas initializr.
+ * Information about versions of CAS supported by the CAS Initializr.
+ * @author Hal Deadman
  */
 @Getter
 @Setter

--- a/app/src/main/java/org/apereo/cas/initializr/config/SupportedVersion.java
+++ b/app/src/main/java/org/apereo/cas/initializr/config/SupportedVersion.java
@@ -1,0 +1,17 @@
+package org.apereo.cas.initializr.config;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Information about versions of CAS supported by the cas initializr.
+ */
+@Getter
+@Setter
+public class SupportedVersion {
+
+    private String casVersion;
+
+    private String bootVersion;
+
+}

--- a/app/src/main/java/org/apereo/cas/initializr/web/SupportedVersionsEndpoint.java
+++ b/app/src/main/java/org/apereo/cas/initializr/web/SupportedVersionsEndpoint.java
@@ -2,11 +2,14 @@ package org.apereo.cas.initializr.web;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.apereo.cas.initializr.config.CasCustomInitializrConfiguration;
 import org.apereo.cas.initializr.config.SupportedVersion;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 
+/**
+ * Actuator that CI uses to get supported version matrix.
+ * @author Hal Deadman
+ */
 @Endpoint(id = "supportedVersions")
 @RequiredArgsConstructor
 public class SupportedVersionsEndpoint

--- a/app/src/main/java/org/apereo/cas/initializr/web/SupportedVersionsEndpoint.java
+++ b/app/src/main/java/org/apereo/cas/initializr/web/SupportedVersionsEndpoint.java
@@ -1,0 +1,20 @@
+package org.apereo.cas.initializr.web;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apereo.cas.initializr.config.CasCustomInitializrConfiguration;
+import org.apereo.cas.initializr.config.SupportedVersion;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+
+@Endpoint(id = "supportedVersions")
+@RequiredArgsConstructor
+public class SupportedVersionsEndpoint
+{
+    private final List<SupportedVersion> supportedVersions;
+
+    @ReadOperation
+    public List<SupportedVersion> getSupportedVersions() {
+        return supportedVersions;
+    }
+}

--- a/app/src/main/resources/META-INF/spring.factories
+++ b/app/src/main/resources/META-INF/spring.factories
@@ -12,3 +12,5 @@ io.spring.initializr.generator.buildsystem.BuildSystemFactory=\
   org.apereo.cas.overlay.configserver.buildsystem.CasConfigServerOverlayBuildSystemFactory,\
   org.apereo.cas.overlay.discoveryserver.buildsystem.CasDiscoveryServerOverlayBuildSystemFactory,\
   org.apereo.cas.overlay.bootadminserver.buildsystem.CasSpringBootAdminServerOverlayBuildSystemFactory
+
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.apereo.cas.initializr.config.CasCustomInitializrConfiguration

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -39,8 +39,8 @@ cas-initializr:
   supported-versions:
     - cas-version: 6.3.3
       boot-version: 2.3.7.RELEASE
-    - cas-version: 6.4.0-RC2
-      boot-version: 2.4.3
+    - cas-version: @casVersion@
+      boot-version: @springBootVersion@
     - cas-version: 6.4.0-SNAPSHOT
       boot-version: 2.4.4
 

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -14,7 +14,7 @@ management:
     enabled-by-default: false
     web:
       exposure:
-        include: 'info,health,shutdown'
+        include: 'info,health,shutdown,supportedVersions'
   endpoint:
     info:
       enabled: true
@@ -22,6 +22,8 @@ management:
       enabled: true
     shutdown:
       enabled: ${SHUTDOWN_ENABLED:true}
+    supportedVersions:
+      enabled: true
 
 logging:
   level:
@@ -32,6 +34,15 @@ logging:
 spring:
   main:
     allow-bean-definition-overriding: true
+
+cas-initializr:
+  supported-versions:
+    - cas-version: 6.3.3
+      boot-version: 2.3.7.RELEASE
+    - cas-version: 6.4.0-RC2
+      boot-version: 2.4.3
+    - cas-version: 6.4.0-SNAPSHOT
+      boot-version: 2.4.4
 
 initializr:
   name:

--- a/app/src/main/resources/common/gradle/build.gradle.mustache
+++ b/app/src/main/resources/common/gradle/build.gradle.mustache
@@ -9,10 +9,12 @@ buildscript {
         mavenLocal()
         mavenCentral()
         gradlePluginPortal()
+        {{#casServer}}
         maven {
             url 'https://oss.sonatype.org/content/repositories/snapshots'
             mavenContent { snapshotsOnly() }
         }
+        {{/casServer}}
     }
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${project.springBootVersion}"

--- a/app/src/main/resources/common/gradle/build.gradle.mustache
+++ b/app/src/main/resources/common/gradle/build.gradle.mustache
@@ -9,6 +9,10 @@ buildscript {
         mavenLocal()
         mavenCentral()
         gradlePluginPortal()
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots'
+            mavenContent { snapshotsOnly() }
+        }
     }
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${project.springBootVersion}"

--- a/ci/validate-cas-overlay.sh
+++ b/ci/validate-cas-overlay.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CAS_VERSION=${1:-6.4.0-SNAPSHOT}
-CAS_VERSION=${2:-2.4.2}
+BOOT_VERSION=${2:-2.4.2}
 
 source ./ci/functions.sh
 

--- a/ci/validate-cas-overlay.sh
+++ b/ci/validate-cas-overlay.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 CAS_VERSION=${1:-6.4.0-SNAPSHOT}
+CAS_VERSION=${2:-2.4.2}
 
 source ./ci/functions.sh
 
@@ -9,7 +10,7 @@ pid=$!
 sleep 15
 mkdir tmp
 cd tmp
-curl http://localhost:8080/starter.tgz -d "casVersion=${CAS_VERSION}" | tar -xzvf -
+curl http://localhost:8080/starter.tgz -d "casVersion=${CAS_VERSION}&bootVersion=${BOOT_VERSION}" | tar -xzvf -
 kill -9 $pid
 
 ./gradlew clean build

--- a/ci/validate-cas-overlay.sh
+++ b/ci/validate-cas-overlay.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CAS_VERSION=${1:-6.4.0-SNAPSHOT}
+
 source ./ci/functions.sh
 
 java -jar app/build/libs/app.jar &
@@ -7,7 +9,7 @@ pid=$!
 sleep 15
 mkdir tmp
 cd tmp
-curl http://localhost:8080/starter.tgz | tar -xzvf -
+curl http://localhost:8080/starter.tgz -d "casVersion=${CAS_VERSION}" | tar -xzvf -
 kill -9 $pid
 
 ./gradlew clean build

--- a/ci/validate-cas-overlay.sh
+++ b/ci/validate-cas-overlay.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CAS_VERSION=${1:-6.4.0-SNAPSHOT}
-BOOT_VERSION=${2:-2.4.2}
+BOOT_VERSION=${2:-2.4.4}
 
 source ./ci/functions.sh
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ version = 0.0.4
 sourceCompatibility = 11
 
 tomcatVersion=9.0.44
-springBootVersion=2.4.4
+springBootVersion=2.4.3
 springInitializrVersion=0.10.1
 jibVersion=2.8.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ version = 0.0.4
 sourceCompatibility = 11
 
 tomcatVersion=9.0.44
-springBootVersion=2.4.2
+springBootVersion=2.4.4
 springInitializrVersion=0.10.1
 jibVersion=2.8.0
 


### PR DESCRIPTION
I had to add snapshots repo to the buildscript repositories list in order to build with 6.4.0-SNAPSHOT. Since I added another matrix, it isn't letting me merge this b/c it is looking for the status of the top level `validate-cas-overlay`.  @mmoayyed - I think you fixed this before for a different matrix. 
I updated the spring boot version used by initializr to use 2.4.3 which matches version used by the default CAS version of 6.4.0-RC2. 