### PR TITLE
allow optional private repository to be used

### DIFF
--- a/app/src/main/resources/common/gradle/build.gradle.mustache
+++ b/app/src/main/resources/common/gradle/build.gradle.mustache
@@ -6,7 +6,7 @@ import static org.gradle.internal.logging.text.StyledTextOutput.Style
 
 buildscript {
     repositories {
-        if (Boolean.valueOf(project.usePrivateRepo)) {
+        if (project.privateRepoUrl) {
           maven {
             url project.privateRepoUrl
             credentials {
@@ -42,7 +42,7 @@ buildscript {
 }
 
 repositories {
-    if (Boolean.valueOf(project.usePrivateRepo)) {
+    if (project.privateRepoUrl) {
       maven {
         url project.privateRepoUrl
         credentials {

--- a/app/src/main/resources/common/gradle/build.gradle.mustache
+++ b/app/src/main/resources/common/gradle/build.gradle.mustache
@@ -6,6 +6,15 @@ import static org.gradle.internal.logging.text.StyledTextOutput.Style
 
 buildscript {
     repositories {
+        if (Boolean.valueOf(project.usePrivateRepo)) {
+          maven {
+            url project.privateRepoUrl
+            credentials {
+              username = project.privateRepoUsername
+              password = System.env.PRIVATE_REPO_TOKEN
+            }
+          }
+        }
         mavenLocal()
         mavenCentral()
         gradlePluginPortal()
@@ -33,6 +42,15 @@ buildscript {
 }
 
 repositories {
+    if (Boolean.valueOf(project.usePrivateRepo)) {
+      maven {
+        url project.privateRepoUrl
+        credentials {
+          username = project.privateRepoUsername
+          password = System.env.PRIVATE_REPO_TOKEN
+        }
+      }
+    }
     mavenLocal()
     mavenCentral()
     jcenter()

--- a/app/src/main/resources/common/gradle/gradle.properties.mustache
+++ b/app/src/main/resources/common/gradle/gradle.properties.mustache
@@ -70,6 +70,5 @@ tomcatVersion=@tomcatVersion@
 
 # Include private repository
 # override these in user properties or pass in values from env on command line
-usePrivateRepo=false
-privateRepoUrl=https://privaterepo/url
-privateRepoUsername=privaterepouser
+privateRepoUrl=
+privateRepoUsername=

--- a/app/src/main/resources/common/gradle/gradle.properties.mustache
+++ b/app/src/main/resources/common/gradle/gradle.properties.mustache
@@ -67,3 +67,9 @@ gradleDownloadTaskVersion=@gradleDownloadTaskPluginVersion@
 # Control the version of the embedded Apache Tomcat server
 tomcatVersion=@tomcatVersion@
 {{/casServer}}
+
+# Include private repository
+# override these in user properties or pass in values from env on command line
+usePrivateRepo=false
+privateRepoUrl=https://privaterepo/url
+privateRepoUsername=privaterepouser


### PR DESCRIPTION
This adds the ability to use a private repository without modifying the build.gradle file. If you don't think this is appropriate then it's not a big deal, just figured I would put it out there since I tested it out locally for blog post I am working on. The flag that turns on the private repo, the repo url and the username are all gradle properties as they would likely not change for a particular user or organization and could be configured in ~/.gradle/gradle.properties or on the command line (where they could use environment variables or CICD secrets). For the password I just used an environment variable b/c that is less appropriate for storing in property file or on command line and in case of AWS CodeArtifact repository it needs to be generated for each build since it is only good for 12 hours. I think setting password via environment variable would work for most repository types that I am aware of and most build scenarios, but maybe it should use elvis operator and fallback to environment variable if a property is not set. 