### PR TITLE
Fix dependencies for 2 tasks

### DIFF
--- a/app/src/main/resources/common/gradle/build.gradle.mustache
+++ b/app/src/main/resources/common/gradle/build.gradle.mustache
@@ -328,7 +328,7 @@ task debugShell(group: "Shell", description: "Run the CAS shell with debug optio
 }
 
 task listTemplateViews(group: "CAS", description: "List all CAS views") {
-    dependsOn unzipWAR
+    dependsOn unzip
 
     doFirst {
         fileTree(explodedResourcesDir).matching {
@@ -374,7 +374,7 @@ task exportConfigMetadata(group: "CAS", description: "Export collection of CAS p
 }
 
 task getResource(group: "CAS", description: "Fetch a CAS resource and move it into the overlay") {
-    dependsOn unzipWAR
+    dependsOn unzip
 
     doFirst {
         def resourceName = project.getProperty("resourceName")


### PR DESCRIPTION
 * listTemplateViews
 * getResource

These two tasks were failing because their dependencies were set to unzipWAR instead of unzip. The unzip task is the one that actually explodes the WAR file so that these two tasks can find resources.