### PR TITLE
Escape multiline comments in the properties with a hash-sign

### DIFF
--- a/app/src/main/resources/overlay/etc/cas/config/all-cas-properties.ref
+++ b/app/src/main/resources/overlay/etc/cas/config/all-cas-properties.ref
@@ -1,7 +1,7 @@
 ############################################################
 # Reference: All CAS Properties
 ############################################################
-# This file contains a catalog of all CAS-owned properties.
+# This file contains a catalog of all CAS-owned properties (version {{casVersion}}).
 #
 # Each property definition is annotated with:
 #   - Description
@@ -19,12 +19,12 @@
 # to upgrade headaches, maintenance nightmares and premature aging.
 ###############################################################################################################
 
-{{#properties}}
+{{#model.properties}}
 # Required: {{required}}
 # Type: {{{type}}}
 # Owner: {{owner}}
 # Module: {{module}}
-# {{{description}}}
+# Description: {{#comment}}{{{description}}}{{/comment}}
 # {{name}}: {{defaultValue}}
 {{#deprecationLevel}}
 # Deprecation Level: {{deprecationLevel}}
@@ -36,4 +36,4 @@
 # Deprecation Replacement: {{deprecationReplacement}}
 {{/deprecationReplacement}}
 
-{{/properties}}
+{{/model.properties}}

--- a/app/src/main/resources/overlay/etc/cas/config/all-properties.ref
+++ b/app/src/main/resources/overlay/etc/cas/config/all-properties.ref
@@ -2,7 +2,7 @@
 # Reference: All Properties
 ############################################################
 # This file contains a catalog of all properties
-# that are not owned/controlled by CAS.
+# that are not owned/controlled by CAS (version {{casVersion}}).
 #
 # Each property definition is annotated with:
 #   - Description
@@ -17,12 +17,12 @@
 # to upgrade headaches, maintenance nightmares and premature aging.
 ###############################################################################################################
 
-{{#properties}}
+{{#model.properties}}
 {{#owner}}
 # Owner: {{owner}}
 {{/owner}}
 # Type: {{{type}}}
-# {{{description}}}
+# Description: {{#comment}}{{{description}}}{{/comment}}
 # {{name}}: {{defaultValue}}
 {{#deprecationLevel}}
 # Deprecation Level: {{deprecationLevel}}
@@ -34,4 +34,4 @@
 # Deprecation Replacement: {{deprecationReplacement}}
 {{/deprecationReplacement}}
 
-{{/properties}}
+{{/model.properties}}

--- a/app/src/main/resources/overlay/etc/cas/config/cas.properties.mustache
+++ b/app/src/main/resources/overlay/etc/cas/config/cas.properties.mustache
@@ -5,12 +5,12 @@ logging.config=file:/etc/cas/config/log4j2.xml
 
 # cas.authn.accept.enabled=false
 
-{{#properties}}
+{{#model.properties}}
 # Required: {{required}}
 # Type: {{{type}}}
 # Owner: {{owner}}
 # Module: {{module}}
-# {{{description}}}
+# Description: {{#comment}}{{{description}}}{{/comment}}
 # {{name}}: {{defaultValue}}
 {{#deprecationLevel}}
 # Deprecation Level: {{deprecationLevel}}
@@ -22,4 +22,4 @@ logging.config=file:/etc/cas/config/log4j2.xml
 # Deprecation Replacement: {{deprecationReplacement}}
 {{/deprecationReplacement}}
 
-{{/properties}}
+{{/model.properties}}


### PR DESCRIPTION
Some descriptions of properties contain html code, that gets translated
into multiline strings. Those strings are not starting with a hash-sign
and will generate invalid properties files.

Introduce a `comment` function, that can be used by the template engine
to escape these multiline strings into valid multiline strings, where
each line starts with a hash-sign. The comment function strips carriage
returns chars, as in my experiments the resulting property files had no
such chars at other line endings.

As the `comment` function has to be placed in the model of the template
execution, the properties will be placed inside of the `templateVariables`
instead of replacing them completely. That leads to changes in the templates,
where references to `properties` have to be changed to `model.properties`.