### PR TITLE
Make lombok.config available to Gradle build in Docker

### DIFF
--- a/app/src/main/resources/overlay/docker/Dockerfile
+++ b/app/src/main/resources/overlay/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM adoptopenjdk/openjdk11:alpine-slim AS overlay
 RUN mkdir -p cas-overlay
 COPY ./src cas-overlay/src/
 COPY ./gradle/ cas-overlay/gradle/
-COPY ./gradlew ./settings.gradle ./build.gradle ./gradle.properties /cas-overlay/
+COPY ./gradlew ./settings.gradle ./build.gradle ./gradle.properties ./lombok.config /cas-overlay/
 
 RUN mkdir -p ~/.gradle \
     && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties \


### PR DESCRIPTION
Hi! We experienced a compile error in some custom classes during the Gradle build in Docker, using [cas-overlay-template:6.4](https://github.com/apereo/cas-overlay-template/tree/6.4):

```
> Task :compileJava
  [91m/cas-overlay/src/main/java/com/example/Example.java:42: error: cannot find symbol
              LOGGER.info("<redacted>");
              ^
    symbol:   variable LOGGER
    location: class Example
```

The root cause is the missing `lombok.config` in the Docker build container.

This PR adds the missing file to the Docker image to make it available during the Gradle build.