### PR TITLE
fix entrypoint syntax issues

### DIFF
--- a/app/src/main/resources/common/jib/entrypoint.sh.mustache
+++ b/app/src/main/resources/common/jib/entrypoint.sh.mustache
@@ -7,24 +7,24 @@ JVM_DEBUG_SUSPEND=${JVM_DEBUG_SUSPEND:-n}
 JVM_MEM_OPTS=${JVM_MEM_OPTS:--Xms512m -Xmx4096M}
 JVM_EXTRA_OPTS=${JVM_EXTRA_OPTS:--server -noverify -XX:+TieredCompilation -XX:TieredStopAtLevel=1}
 
-if [ $JVM_DEBUG == "true" ]; then
+if [ $JVM_DEBUG = "true" ]; then
   JVM_EXTRA_OPTS="${JVM_EXTRA_OPTS} -Xdebug -Xrunjdwp:transport=dt_socket,address=*:${JVM_DEBUG_PORT},server=y,suspend=${JVM_DEBUG_SUSPEND}"
 fi
 
-if [ $ENTRYPOINT_DEBUG == "true" ]; then
+if [ $ENTRYPOINT_DEBUG = "true" ]; then
   JVM_EXTRA_OPTS="${JVM_EXTRA_OPTS} -Ddebug=true"
   
-  echo -e "\nChecking java..."
+  echo "\nChecking java..."
   java -version
 
   if [ -d /etc/cas ] ; then
-    echo -e "\nListing CAS configuration under /etc/cas..."
+    echo "\nListing CAS configuration under /etc/cas..."
     ls -R /etc/cas
   fi
-  echo -e "\nRemote debugger configured on port ${JVM_DEBUG_PORT} with suspend=${JVM_DEBUG_SUSPEND}: ${JVM_DEBUG}"
-  echo -e "\nJava args: ${JVM_MEM_OPTS} ${JVM_EXTRA_OPTS}"
+  echo "\nRemote debugger configured on port ${JVM_DEBUG_PORT} with suspend=${JVM_DEBUG_SUSPEND}: ${JVM_DEBUG}"
+  echo "\nJava args: ${JVM_MEM_OPTS} ${JVM_EXTRA_OPTS}"
 fi
 
-echo -e "\nRunning CAS @ {{appName}}.war"
+echo "\nRunning CAS @ {{appName}}.war"
 # shellcheck disable=SC2086
 exec java $JVM_EXTRA_OPTS $JVM_MEM_OPTS -jar {{appName}}.war "$@"


### PR DESCRIPTION
I was seeing the following when running apereo/cas:6.6.6 container:

```
./entrypoint.sh: 10: [: false: unexpected operator
./entrypoint.sh: 14: [: false: unexpected operator
```
Apparently can't use == in [] in non-bash shell. [Stack Overflow](https://stackoverflow.com/questions/18102454/why-am-i-getting-an-unexpected-operator-error-in-bash-string-equality-test)

Also the `-e` argument in echo is showing up in the output and doesn't seem to be necessary. From inside the `apereo/cas:6.6.6` image:
```
# echo "\nHi"

Hi
# echo -e "\nHi"
-e
Hi
```