### PR TITLE
disable configuration cache for createKeyStore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmp
 *.class
 .java-version
 .DS_Store
+.yarn

--- a/app/src/main/resources/overlay/helmcharts/helm/cas-server/templates/service.yaml
+++ b/app/src/main/resources/overlay/helmcharts/helm/cas-server/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "cas-server.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.cas.service.type }}
+  publishNotReadyAddresses: {{ .Values.cas.service.publishNotReadyAddresses }}
   ports:
     - port: {{ .Values.cas.service.port }}
       targetPort: https

--- a/app/src/main/resources/overlay/helmcharts/helm/cas-server/values.yaml
+++ b/app/src/main/resources/overlay/helmcharts/helm/cas-server/values.yaml
@@ -547,6 +547,7 @@ containerSecurityContext:
 cas:
   service:
     type: ClusterIP
+    publishNotReadyAddresses: true
     port: 8443
   listenPortHttps: 8443
   listenPortJvmDebug: 5005

--- a/app/src/main/resources/overlay/helmcharts/helm/create-cas-server-keystore-secret.sh
+++ b/app/src/main/resources/overlay/helmcharts/helm/create-cas-server-keystore-secret.sh
@@ -12,7 +12,7 @@ SAN=dns:cas.example.org,dns:casadmin.example.org,dns:cas-server-boot-admin,dns:c
 
 if [ ! -f "$KEYSTORE" ] ; then
   pushd ..
-  ./gradlew createKeyStore -PcertDir=./etc/cas -PcertificateDn="${SUBJECT}" -PcertificateSubAltName="${SAN}"
+  ./gradlew --no-configuration-cache createKeyStore -PcertDir=./etc/cas -PcertificateDn="${SUBJECT}" -PcertificateSubAltName="${SAN}"
   popd
 fi
 

--- a/ci/validate-helm.sh
+++ b/ci/validate-helm.sh
@@ -18,24 +18,33 @@ if [[ $NAMESPACE != "default" ]]; then
 fi
 
 echo "Creating Keystore and secret for keystore"
+set +e
 ./create-cas-server-keystore-secret.sh $NAMESPACE > tmp.out 2>&1
 if [[ $? -ne 0 ]]; then
   cat tmp.out
+  exit 1
 fi
+set -e
 rm tmp.out
 
 echo "Creating tls secret for ingress to use"
+set +e
 ./create-ingress-tls.sh $NAMESPACE > tmp.out 2>&1
 if [[ $? -ne 0 ]]; then
   cat tmp.out
+  exit 1
 fi
+set -e
 rm tmp.out
 
 echo "Creating truststore with server/ingress certs and put in configmap"
+set +e
 ./create-truststore.sh $NAMESPACE > tmp.out 2>&1
 if [[ $? -ne 0 ]]; then
   cat tmp.out
+  exit 1
 fi
+set -e
 rm tmp.out
 
 # Set KUBECONFIG for helm


### PR DESCRIPTION
Gradle didn't like references to the "project" in the createKeyStore task when build cache was on so I turned it off. I also changed helm chart to publish pod addresses before they are ready so the admin server doesn't complain about cas server dns name not resolving. Also changed script so if errors occur the logs will be dumped to output. 