### PR TITLE
fix javaexec issue when running gradlew run

### DIFF
--- a/app/src/main/resources/common/gradle/tasks.gradle.mustache
+++ b/app/src/main/resources/common/gradle/tasks.gradle.mustache
@@ -27,10 +27,9 @@ task run(group: "build", description: "Run the CAS web application in embedded c
     dependsOn 'build'
     doLast {
         def casRunArgs = Arrays.asList("-server -noverify -Xmx2048M -XX:+TieredCompilation -XX:TieredStopAtLevel=1".split(" "))
-        javaexec {
-            main = "-jar"
+        project.javaexec {
             jvmArgs = casRunArgs
-            args = ["build/libs/{{appName}}.war"]
+            classpath = project.files("build/libs/{{appName}}.war")
             systemProperties = System.properties
             logger.info "Started ${commandLine}"
         }
@@ -62,11 +61,10 @@ task debug(group: "CAS", description: "Debug the CAS web application in embedded
     doLast {
         logger.info "Debugging process is started in a suspended state, listening on port 5005."
         def casArgs = Arrays.asList("-Xmx2048M".split(" "))
-        javaexec {
-            main = "-jar"
+        project.javaexec {
             jvmArgs = casArgs
             debug = true
-            args = ["build/libs/{{appName}}.war"]
+            classpath = project.files("build/libs/{{appName}}.war")
             systemProperties = System.properties
             logger.info "Started ${commandLine}"
         }


### PR DESCRIPTION
Hello,

When I use the cas overlay on branch 6.6 (https://github.com/apereo/cas-overlay-template/tree/6.6), and run the command

`./gradlew run`

I get the following error:

```
> Could not find method javaexec() for arguments
[tasks_bnmzyqkmruvlr0afz0ublnm6w$_run_closure1$_closure25$_closure26@4b80fab3]
on task ':run' of type org.gradle.api.DefaultTask.
```

This PR fixes the error.

See also https://docs.gradle.org/current/userguide/upgrading_version_7.html#javaexec_api_cleanup for gradle 8 migrations steps about javaexec task.