### PR TITLE
Move Dockerfile ARGs to correct build stage.

### DIFF
--- a/app/src/main/resources/overlay/docker/Dockerfile.mustache
+++ b/app/src/main/resources/overlay/docker/Dockerfile.mustache
@@ -1,8 +1,9 @@
 ARG BASE_IMAGE="{{containerBaseImageName}}"
-ARG EXT_BUILD_COMMANDS=""
-ARG EXT_BUILD_OPTIONS=""
 
 FROM $BASE_IMAGE AS overlay
+
+ARG EXT_BUILD_COMMANDS=""
+ARG EXT_BUILD_OPTIONS=""
 
 RUN mkdir -p cas-overlay
 COPY ./src cas-overlay/src/


### PR DESCRIPTION
The ARGs "EXT_BUILD_COMMANDS" and "EXT_BUILD_OPTIONS" in the Dockerfile do not work because they are in the wrong build stage. The FROM command creates a new build stage and scope. ARGs defined in the previous build stage become out of scope. See https://docs.docker.com/engine/reference/builder/#scope and https://github.com/containers/podman/issues/9392#issuecomment-779885225.