### PR TITLE
Replace RUN cd with WORKDIR

### DIFF
--- a/app/src/main/resources/overlay/docker/Dockerfile.mustache
+++ b/app/src/main/resources/overlay/docker/Dockerfile.mustache
@@ -13,7 +13,6 @@ COPY ./gradlew ./settings.gradle ./build.gradle ./gradle.properties ./lombok.con
 RUN mkdir -p ~/.gradle \
     && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties \
     && echo "org.gradle.configureondemand=true" >> ~/.gradle/gradle.properties \
-    && cd cas-overlay \
     && chmod 750 ./gradlew \
     && ./gradlew --version;
 

--- a/app/src/main/resources/overlay/docker/Dockerfile.mustache
+++ b/app/src/main/resources/overlay/docker/Dockerfile.mustache
@@ -5,10 +5,10 @@ FROM $BASE_IMAGE AS overlay
 ARG EXT_BUILD_COMMANDS=""
 ARG EXT_BUILD_OPTIONS=""
 
-RUN mkdir -p cas-overlay
-COPY ./src cas-overlay/src/
-COPY ./gradle/ cas-overlay/gradle/
-COPY ./gradlew ./settings.gradle ./build.gradle ./gradle.properties ./lombok.config /cas-overlay/
+WORKDIR /cas-overlay
+COPY ./src src/
+COPY ./gradle/ gradle/
+COPY ./gradlew ./settings.gradle ./build.gradle ./gradle.properties ./lombok.config ./
 
 RUN mkdir -p ~/.gradle \
     && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties \
@@ -17,11 +17,9 @@ RUN mkdir -p ~/.gradle \
     && chmod 750 ./gradlew \
     && ./gradlew --version;
 
-RUN cd cas-overlay \
-    && ./gradlew clean build $EXT_BUILD_COMMANDS --parallel --no-daemon -Pexecutable=false $EXT_BUILD_OPTIONS;
+RUN ./gradlew clean build $EXT_BUILD_COMMANDS --parallel --no-daemon -Pexecutable=false $EXT_BUILD_OPTIONS;
 
-RUN cd cas-overlay \
-    && java -Djarmode=tools -jar build/libs/cas.war extract \
+RUN java -Djarmode=tools -jar build/libs/cas.war extract \
     && java -XX:ArchiveClassesAtExit=./cas/cas.jsa -Dspring.context.exit=onRefresh -jar cas/cas.war
 
 FROM $BASE_IMAGE AS cas
@@ -29,13 +27,12 @@ FROM $BASE_IMAGE AS cas
 LABEL "Organization"="Apereo"
 LABEL "Description"="Apereo CAS"
 
-RUN cd / \
-    && mkdir -p /etc/cas/config \
+RUN mkdir -p /etc/cas/config \
     && mkdir -p /etc/cas/services \
-    && mkdir -p /etc/cas/saml \
-    && mkdir -p cas-overlay;
+    && mkdir -p /etc/cas/saml;
 
-COPY --from=overlay cas-overlay/cas cas-overlay/cas/
+WORKDIR cas-overlay
+COPY --from=overlay /cas-overlay/cas cas/
 
 COPY etc/cas/ /etc/cas/
 COPY etc/cas/config/ /etc/cas/config/
@@ -46,5 +43,4 @@ EXPOSE 8080 8443
 
 ENV PATH $PATH:$JAVA_HOME/bin:.
 
-WORKDIR cas-overlay
 ENTRYPOINT ["java", "-server", "-noverify", "-Xmx2048M", "-XX:SharedArchiveFile=cas/cas.jsa", "-jar", "cas/cas.war"]


### PR DESCRIPTION
Using `RUN cd` is bad practice.

> you should use WORKDIR instead of proliferating instructions like RUN cd … && do-something, which are hard to read, troubleshoot, and maintain.

https://docs.docker.com/build/building/best-practices/#workdir

Furthermore, using WORKDIR saves us repeated use of `cd` and even some `mkdir -p`.