### PR TITLE
update appServer check for tomcat

### DIFF
--- a/app/src/main/resources/common/gradle/build.gradle.mustache
+++ b/app/src/main/resources/common/gradle/build.gradle.mustache
@@ -462,7 +462,7 @@ dependencies {
     implementation "org.apereo.cas:cas-server-core-api-configuration-model"
     implementation "org.apereo.cas:cas-server-webapp-init"
 
-    if (appServer == 'tomcat') {
+    if (appServer == '-tomcat') {
         implementation "org.apereo.cas:cas-server-webapp-init-tomcat"
     }
     


### PR DESCRIPTION
I believe the `appServer` property needs to check for `-tomcat`.  If we build with both `appServer=-tomcat` and include `tomcatVersion=10.1.xx` we end up without an app server.